### PR TITLE
updated to .net 9

### DIFF
--- a/ArraysAndLists/ArraysAndLists.csproj
+++ b/ArraysAndLists/ArraysAndLists.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes a change to the `ArraysAndLists/ArraysAndLists.csproj` file. The change updates the target framework from .NET 6.0 to .NET 9.0.

* [`ArraysAndLists/ArraysAndLists.csproj`](diffhunk://#diff-ae5ed11c9c8c998d3e2f8aae7c6eaece3e4a36c2e279cd101cc7a33b5c3d420fL5-R5): Updated the `<TargetFramework>` property from `net6.0` to `net9.0`.